### PR TITLE
fix getSecretHelper stores the secret value  to the wrong cache key

### DIFF
--- a/src/helpers/client.ts
+++ b/src/helpers/client.ts
@@ -44,7 +44,7 @@ export async function getSecretHelper(instance: InfisicalClient, secretName: str
             type: options.type
         });
         
-        instance.cache[secretName] = secretBundle;
+        instance.cache[`${secretBundle.type}-${secretBundle.secretName}`] = secretBundle;
         
         return secretBundle;
     


### PR DESCRIPTION
The `getSecretHelper` function did store the retrieved secret with a wrong cache key.