### PR TITLE
Add support for Service Token V3 (Beta)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 All notable changes will be documented in this file.
 
+## [1.4.0] - 2023-07-29
+
+This version adds support for the Service Token V3 (Beta) authentication method for Infisical which is a JSON; note that it continues to support Service Token V2 (the default authentication method at this time). With this update, it's possible to initialize the InfisicalClient with a Service Token V3 JSON via the `tokenJSON` parameter to perform CRUD secret operations.
+
+Example:
+
+```
+const client = new InfisicalClient({
+    tokenJson: process.env.INFISICAL_TOKEN_JSON!,
+    siteURL: process.env.SITE_URL!,
+    debug: true
+});
+```
+
 ## [1.3.2] - 2023-07-13
 
 This version adds support for attaching fetched secrets to `process.env` object by setting the `attachToProcessEnv` option on `getAllSecrets`.

--- a/README.md
+++ b/README.md
@@ -106,11 +106,26 @@ const client = new InfisicalClient({
 // your app logic
 ```
 
+Using Infisical Token V3 (Beta):
+
+In `v1.4.0`, we released a superior token authentication method; this credential is a JSON containing a `publicKey`, privateKey`, and `serviceToken` and can be used to initialize the Node SDK client instead of the regular Infisical Token.
+
+You can use this beta feature like so:
+
+```js
+const InfisicalClient = require("infisical-node");
+
+const client = new InfisicalClient({
+  tokenJson: "your_infisical_token_v3_json",
+});
+```
+
 ### Options
 
 | Parameter  | Type      | Description                                                                |
 | ---------- | --------- | -------------------------------------------------------------------------- |
-| `token`    | `string`  | An Infisical Token scoped to a project and environment.                    |
+| `token`    | `string`  | An Infisical Token scoped to a project and environment(s).                 |
+| `tokenJson`| `string`  | An Infisical Token V3 JSON scoped to a project and environment(s) - in beta|
 | `siteURL`  | `string`  | Your self-hosted Infisical site URL. Default: `https://app.infisical.com`. |
 | `cacheTTL` | `number`  | Time-to-live (in seconds) for refreshing cached secrets. Default: `300`.   |
 | `debug`    | `boolean` | Turns debug mode on or off. Default: `false`.                              |

--- a/lib/api/serviceTokenData/index.d.ts
+++ b/lib/api/serviceTokenData/index.d.ts
@@ -1,1 +1,1 @@
-export { getServiceTokenData } from './queries';
+export * from "./queries";

--- a/lib/api/serviceTokenData/index.js
+++ b/lib/api/serviceTokenData/index.js
@@ -1,5 +1,17 @@
 "use strict";
+var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    var desc = Object.getOwnPropertyDescriptor(m, k);
+    if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
+      desc = { enumerable: true, get: function() { return m[k]; } };
+    }
+    Object.defineProperty(o, k2, desc);
+}) : (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    o[k2] = m[k];
+}));
+var __exportStar = (this && this.__exportStar) || function(m, exports) {
+    for (var p in m) if (p !== "default" && !Object.prototype.hasOwnProperty.call(exports, p)) __createBinding(exports, m, p);
+};
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.getServiceTokenData = void 0;
-var queries_1 = require("./queries");
-Object.defineProperty(exports, "getServiceTokenData", { enumerable: true, get: function () { return queries_1.getServiceTokenData; } });
+__exportStar(require("./queries"), exports);

--- a/lib/api/serviceTokenData/queries.d.ts
+++ b/lib/api/serviceTokenData/queries.d.ts
@@ -1,5 +1,8 @@
 import { AxiosInstance } from 'axios';
-import { IServiceTokenData } from '../../types/models';
+import { IServiceTokenData, ServiceTokenDataKeyRes } from '../../types/models';
 export declare const getServiceTokenData: ({ apiRequest }: {
     apiRequest: AxiosInstance;
 }) => Promise<IServiceTokenData>;
+export declare const getServiceTokenDataKey: ({ apiRequest }: {
+    apiRequest: AxiosInstance;
+}) => Promise<ServiceTokenDataKeyRes>;

--- a/lib/api/serviceTokenData/queries.js
+++ b/lib/api/serviceTokenData/queries.js
@@ -36,7 +36,7 @@ var __generator = (this && this.__generator) || function (thisArg, body) {
     }
 };
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.getServiceTokenData = void 0;
+exports.getServiceTokenDataKey = exports.getServiceTokenData = void 0;
 var getServiceTokenData = function (_a) {
     var apiRequest = _a.apiRequest;
     return __awaiter(void 0, void 0, void 0, function () {
@@ -52,3 +52,18 @@ var getServiceTokenData = function (_a) {
     });
 };
 exports.getServiceTokenData = getServiceTokenData;
+var getServiceTokenDataKey = function (_a) {
+    var apiRequest = _a.apiRequest;
+    return __awaiter(void 0, void 0, void 0, function () {
+        var data;
+        return __generator(this, function (_b) {
+            switch (_b.label) {
+                case 0: return [4 /*yield*/, apiRequest.get("/api/v3/service-token/me/key")];
+                case 1:
+                    data = (_b.sent()).data;
+                    return [2 /*return*/, data];
+            }
+        });
+    });
+};
+exports.getServiceTokenDataKey = getServiceTokenDataKey;

--- a/lib/client/InfisicalClient.d.ts
+++ b/lib/client/InfisicalClient.d.ts
@@ -1,11 +1,11 @@
 import { ISecretBundle } from '../types/models';
-import { ServiceTokenClientConfig, GetAllOptions, GetOptions, CreateOptions, UpdateOptions, DeleteOptions, InfisicalClientOptions } from '../types/InfisicalClient';
+import { ClientConfig, GetAllOptions, GetOptions, CreateOptions, UpdateOptions, DeleteOptions, InfisicalClientOptions } from '../types/InfisicalClient';
 import { IEncryptSymmetricOutput } from '../types/utils';
 declare class InfisicalClient {
     cache: {
         [key: string]: ISecretBundle;
     };
-    clientConfig: ServiceTokenClientConfig | undefined;
+    clientConfig: ClientConfig | undefined;
     debug: boolean;
     /**
      * Create an instance of the Infisical client
@@ -14,7 +14,7 @@ declare class InfisicalClient {
      * @param {Boolean} debug - whether debug is on
      * @param {Number} cacheTTL - time-to-live (in seconds) for refreshing cached secrets.
      */
-    constructor({ token, siteURL, debug, cacheTTL }: InfisicalClientOptions);
+    constructor({ token, tokenJson, siteURL, debug, cacheTTL }: InfisicalClientOptions);
     /**
     * Return all the secrets accessible by the instance of Infisical
     */

--- a/lib/client/InfisicalClient.js
+++ b/lib/client/InfisicalClient.js
@@ -49,7 +49,7 @@ var InfisicalClient = /** @class */ (function () {
      * @param {Number} cacheTTL - time-to-live (in seconds) for refreshing cached secrets.
      */
     function InfisicalClient(_a) {
-        var _b = _a.token, token = _b === void 0 ? undefined : _b, _c = _a.siteURL, siteURL = _c === void 0 ? variables_1.INFISICAL_URL : _c, _d = _a.debug, debug = _d === void 0 ? false : _d, _e = _a.cacheTTL, cacheTTL = _e === void 0 ? 300 : _e;
+        var _b = _a.token, token = _b === void 0 ? undefined : _b, _c = _a.tokenJson, tokenJson = _c === void 0 ? undefined : _c, _d = _a.siteURL, siteURL = _d === void 0 ? variables_1.INFISICAL_URL : _d, _e = _a.debug, debug = _e === void 0 ? false : _e, _f = _a.cacheTTL, cacheTTL = _f === void 0 ? 300 : _f;
         this.cache = {};
         this.clientConfig = undefined;
         this.debug = false;
@@ -57,13 +57,28 @@ var InfisicalClient = /** @class */ (function () {
             var lastDotIdx = token.lastIndexOf('.');
             var serviceToken = token.substring(0, lastDotIdx);
             this.clientConfig = {
-                authMode: variables_1.AUTH_MODE_SERVICE_TOKEN,
+                authMode: variables_1.AuthMode.SERVICE_TOKEN,
                 credentials: {
                     serviceTokenKey: token.substring(lastDotIdx + 1)
                 },
                 apiRequest: (0, api_1.createApiRequestWithAuthInterceptor)({
                     baseURL: siteURL,
                     serviceToken: serviceToken
+                }),
+                cacheTTL: cacheTTL
+            };
+        }
+        if (tokenJson && tokenJson !== "") {
+            var tokenObj = JSON.parse(tokenJson);
+            this.clientConfig = {
+                authMode: variables_1.AuthMode.SERVICE_TOKEN_V3,
+                credentials: {
+                    publicKey: tokenObj.publicKey,
+                    privateKey: tokenObj.privateKey
+                },
+                apiRequest: (0, api_1.createApiRequestWithAuthInterceptor)({
+                    baseURL: siteURL,
+                    serviceToken: tokenObj.serviceToken
                 }),
                 cacheTTL: cacheTTL
             };

--- a/lib/helpers/key.d.ts
+++ b/lib/helpers/key.d.ts
@@ -1,2 +1,2 @@
-import { ServiceTokenClientConfig, WorkspaceConfig } from '../types/InfisicalClient';
-export declare const populateClientWorkspaceConfigsHelper: (clientConfig: ServiceTokenClientConfig) => Promise<WorkspaceConfig>;
+import { ClientConfig, WorkspaceConfig } from '../types/InfisicalClient';
+export declare const populateClientWorkspaceConfigsHelper: (clientConfig: ClientConfig) => Promise<WorkspaceConfig>;

--- a/lib/helpers/key.js
+++ b/lib/helpers/key.js
@@ -37,17 +37,25 @@ var __generator = (this && this.__generator) || function (thisArg, body) {
 };
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.populateClientWorkspaceConfigsHelper = void 0;
+var variables_1 = require("../variables");
 var api_1 = require("../api");
 var crypto_1 = require("../utils/crypto");
 var populateClientWorkspaceConfigsHelper = function (clientConfig) { return __awaiter(void 0, void 0, void 0, function () {
-    var serviceTokenData, workspaceKey;
-    return __generator(this, function (_a) {
-        switch (_a.label) {
-            case 0: return [4 /*yield*/, (0, api_1.getServiceTokenData)({
+    var _a, serviceTokenData, workspaceKey, _b, workspace, encryptedKey, nonce, publicKey, workspaceKey;
+    return __generator(this, function (_c) {
+        switch (_c.label) {
+            case 0:
+                _a = clientConfig.authMode;
+                switch (_a) {
+                    case variables_1.AuthMode.SERVICE_TOKEN: return [3 /*break*/, 1];
+                    case variables_1.AuthMode.SERVICE_TOKEN_V3: return [3 /*break*/, 3];
+                }
+                return [3 /*break*/, 5];
+            case 1: return [4 /*yield*/, (0, api_1.getServiceTokenData)({
                     apiRequest: clientConfig.apiRequest
                 })];
-            case 1:
-                serviceTokenData = _a.sent();
+            case 2:
+                serviceTokenData = _c.sent();
                 workspaceKey = (0, crypto_1.decryptSymmetric128BitHexKeyUTF8)({
                     ciphertext: serviceTokenData.encryptedKey,
                     iv: serviceTokenData.iv,
@@ -58,6 +66,22 @@ var populateClientWorkspaceConfigsHelper = function (clientConfig) { return __aw
                         workspaceId: serviceTokenData.workspace,
                         workspaceKey: workspaceKey
                     })];
+            case 3: return [4 /*yield*/, (0, api_1.getServiceTokenDataKey)({
+                    apiRequest: clientConfig.apiRequest
+                })];
+            case 4:
+                _b = (_c.sent()).key, workspace = _b.workspace, encryptedKey = _b.encryptedKey, nonce = _b.nonce, publicKey = _b.publicKey;
+                workspaceKey = (0, crypto_1.decryptAsymmetric)({
+                    ciphertext: encryptedKey,
+                    nonce: nonce,
+                    publicKey: publicKey,
+                    privateKey: clientConfig.credentials.privateKey
+                });
+                return [2 /*return*/, ({
+                        workspaceId: workspace,
+                        workspaceKey: workspaceKey
+                    })];
+            case 5: throw Error("Failed to populate workspace config");
         }
     });
 }); };

--- a/lib/services/SecretService.d.ts
+++ b/lib/services/SecretService.d.ts
@@ -1,10 +1,10 @@
 import { GetFallbackSecretParams, GetDecryptedSecretsParams, GetDecryptedSecretParams, CreateSecretParams, UpdateSecretParams, DeleteSecretParams } from '../types/SecretService';
-import { ServiceTokenClientConfig } from '../types/InfisicalClient';
+import { ClientConfig } from '../types/InfisicalClient';
 /**
  * Class for secret-related actions
  */
 export default class SecretService {
-    static populateClientWorkspaceConfig(clientConfig: ServiceTokenClientConfig): Promise<import("../types/InfisicalClient").WorkspaceConfig>;
+    static populateClientWorkspaceConfig(clientConfig: ClientConfig): Promise<import("../types/InfisicalClient").WorkspaceConfig>;
     /**
      * Get fallback secret on [process.env]
      */

--- a/lib/types/InfisicalClient.d.ts
+++ b/lib/types/InfisicalClient.d.ts
@@ -1,7 +1,8 @@
 import { AxiosInstance } from 'axios';
 
 export interface InfisicalClientOptions {
-    token?: string | undefined;
+    token?: string;
+    tokenJson?: string;
     siteURL?: string;
     debug?: boolean;
     cacheTTL?: number;
@@ -16,27 +17,31 @@ interface ServiceTokenCredentials {
     serviceTokenKey: string;
 }
 
-interface ServiceAccountCredentials {
-    serviceAccountPublicKey: string;
-    serviceAccountPrivateKey: string;
-}
-
-interface ClientConfig {
+interface BaseConfig {
     apiRequest: AxiosInstance;
     cacheTTL: number;
 }
 
-export interface ServiceTokenClientConfig extends ClientConfig {
-    authMode: 'serviceToken';
+export interface ServiceTokenClientConfig extends BaseConfig {
+    authMode: "serviceToken"; // TODO: convert to enum
     credentials: ServiceTokenCredentials;
     workspaceConfig?: WorkspaceConfig;
 }
 
-export interface ServiceAccountClientConfig extends ClientConfig {
-    authMode: 'serviceAccount';
-    credentials: ServiceAccountCredentials;
-    workspaceConfig?: WorkspaceConfig[];
+interface ServiceTokenV3Credentials {
+    publicKey: string;
+    privateKey: string;
 }
+
+export interface ServiceTokenV3ClientConfig extends BaseConfig {
+    authMode: "serviceTokenV3"; // TODO: convert to enum
+    credentials: ServiceTokenV3Credentials;
+    workspaceConfig?: WorkspaceConfig;
+}
+
+export type ClientConfig =
+    | ServiceTokenClientConfig
+    | ServiceTokenV3ClientConfig;
 
 type SecretType = 'shared' | 'personal'
 

--- a/lib/types/models.d.ts
+++ b/lib/types/models.d.ts
@@ -51,3 +51,13 @@ export interface Scope {
     envSlug: string;
     path: string
 }
+
+export interface ServiceTokenDataKeyRes {
+    key: {
+        _id: string;    
+        workspace: string;
+        encryptedKey: string;
+        publicKey: string;
+        nonce: string;
+    }
+}

--- a/lib/utils/crypto.d.ts
+++ b/lib/utils/crypto.d.ts
@@ -24,7 +24,7 @@ export declare const encryptAsymmetric: ({ plaintext, publicKey, privateKey }: I
  * @param {String} obj.privateKey - private key of the receiver (current user)
  * @param {String} plaintext - UTF8 plaintext
  */
-export declare const decryptAsymmetric: ({ ciphertext, nonce, publicKey, privateKey }: IDecryptAsymmetricInput) => Uint8Array | null;
+export declare const decryptAsymmetric: ({ ciphertext, nonce, publicKey, privateKey }: IDecryptAsymmetricInput) => string;
 /**
  * Return new base64-encoded, 256-bit symmetric key
  * @returns {String} key - new symmetric key

--- a/lib/utils/crypto.js
+++ b/lib/utils/crypto.js
@@ -61,7 +61,10 @@ exports.encryptAsymmetric = encryptAsymmetric;
  */
 var decryptAsymmetric = function (_a) {
     var ciphertext = _a.ciphertext, nonce = _a.nonce, publicKey = _a.publicKey, privateKey = _a.privateKey;
-    return nacl.box.open(util.decodeBase64(ciphertext), util.decodeBase64(nonce), util.decodeBase64(publicKey), util.decodeBase64(privateKey));
+    var plaintext = nacl.box.open(util.decodeBase64(ciphertext), util.decodeBase64(nonce), util.decodeBase64(publicKey), util.decodeBase64(privateKey));
+    if (plaintext == null)
+        throw Error("Invalid ciphertext or keys");
+    return util.encodeUTF8(plaintext);
 };
 exports.decryptAsymmetric = decryptAsymmetric;
 /**

--- a/lib/variables/index.d.ts
+++ b/lib/variables/index.d.ts
@@ -1,5 +1,8 @@
 export declare const INFISICAL_URL = "https://app.infisical.com";
-export declare const AUTH_MODE_SERVICE_TOKEN = "serviceToken";
+export declare enum AuthMode {
+    SERVICE_TOKEN = "serviceToken",
+    SERVICE_TOKEN_V3 = "serviceTokenV3"
+}
 export declare const ALGORITHM_AES_256_GCM = "aes-256-gcm";
 export declare const IV_BYTES_SIZE = 12;
 export declare const SYMMETRIC_KEY_BYTES_SIZE = 32;

--- a/lib/variables/index.js
+++ b/lib/variables/index.js
@@ -1,8 +1,12 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.ENCODING_SCHEME_BASE64 = exports.ENCODING_SCHEME_HEX = exports.ENCODING_SCHEME_UTF8 = exports.SYMMETRIC_KEY_BYTES_SIZE = exports.IV_BYTES_SIZE = exports.ALGORITHM_AES_256_GCM = exports.AUTH_MODE_SERVICE_TOKEN = exports.INFISICAL_URL = void 0;
+exports.ENCODING_SCHEME_BASE64 = exports.ENCODING_SCHEME_HEX = exports.ENCODING_SCHEME_UTF8 = exports.SYMMETRIC_KEY_BYTES_SIZE = exports.IV_BYTES_SIZE = exports.ALGORITHM_AES_256_GCM = exports.AuthMode = exports.INFISICAL_URL = void 0;
 exports.INFISICAL_URL = 'https://app.infisical.com';
-exports.AUTH_MODE_SERVICE_TOKEN = 'serviceToken';
+var AuthMode;
+(function (AuthMode) {
+    AuthMode["SERVICE_TOKEN"] = "serviceToken";
+    AuthMode["SERVICE_TOKEN_V3"] = "serviceTokenV3";
+})(AuthMode = exports.AuthMode || (exports.AuthMode = {}));
 exports.ALGORITHM_AES_256_GCM = 'aes-256-gcm';
 exports.IV_BYTES_SIZE = 12;
 exports.SYMMETRIC_KEY_BYTES_SIZE = 32;

--- a/src/api/serviceTokenData/index.ts
+++ b/src/api/serviceTokenData/index.ts
@@ -1,3 +1,1 @@
-export {
-    getServiceTokenData
-} from './queries';
+export * from "./queries";

--- a/src/api/serviceTokenData/queries.ts
+++ b/src/api/serviceTokenData/queries.ts
@@ -1,5 +1,8 @@
 import { AxiosInstance } from 'axios';
-import { IServiceTokenData } from '../../types/models';
+import { 
+    IServiceTokenData,
+    ServiceTokenDataKeyRes
+} from '../../types/models';
 
 export const getServiceTokenData = async ({
     apiRequest 
@@ -8,4 +11,13 @@ export const getServiceTokenData = async ({
 }): Promise<IServiceTokenData> => {
     const { data } = await apiRequest.get<IServiceTokenData>('/api/v2/service-token');
     return data;
+}
+
+export const getServiceTokenDataKey = async ({
+    apiRequest
+}: {
+    apiRequest: AxiosInstance;
+}): Promise<ServiceTokenDataKeyRes> => {
+    const { data } = await apiRequest.get<ServiceTokenDataKeyRes>("/api/v3/service-token/me/key");
+    return data
 }

--- a/src/client/InfisicalClient.ts
+++ b/src/client/InfisicalClient.ts
@@ -1,8 +1,11 @@
-import { INFISICAL_URL, AUTH_MODE_SERVICE_TOKEN } from '../variables';
+import { 
+    INFISICAL_URL, 
+    AuthMode,
+} from '../variables';
 import { createApiRequestWithAuthInterceptor } from '../api';
-import { ISecretBundle, Scope } from '../types/models';
+import { ISecretBundle } from '../types/models';
 import {
-    ServiceTokenClientConfig,
+    ClientConfig,
     GetAllOptions,
     GetOptions,
     CreateOptions,
@@ -31,7 +34,7 @@ class InfisicalClient {
 
     public cache: { [key: string]: ISecretBundle } = {}
 
-    public clientConfig: ServiceTokenClientConfig | undefined = undefined;
+    public clientConfig: ClientConfig | undefined = undefined;
     public debug: boolean = false;
 
     /**
@@ -43,6 +46,7 @@ class InfisicalClient {
      */
     constructor({
         token = undefined,
+        tokenJson = undefined,
         siteURL = INFISICAL_URL,
         debug = false,
         cacheTTL = 300
@@ -52,13 +56,30 @@ class InfisicalClient {
             const serviceToken = token.substring(0, lastDotIdx);
 
             this.clientConfig = {
-                authMode: AUTH_MODE_SERVICE_TOKEN,
+                authMode: AuthMode.SERVICE_TOKEN,
                 credentials: {
                     serviceTokenKey: token.substring(lastDotIdx + 1)
                 },
                 apiRequest: createApiRequestWithAuthInterceptor({
                     baseURL: siteURL,
                     serviceToken
+                }),
+                cacheTTL
+            }
+        }
+        
+        if (tokenJson && tokenJson !== "") {
+            const tokenObj = JSON.parse(tokenJson);
+            
+            this.clientConfig = {
+                authMode: AuthMode.SERVICE_TOKEN_V3,
+                credentials: {
+                    publicKey: tokenObj.publicKey,
+                    privateKey: tokenObj.privateKey
+                },
+                apiRequest: createApiRequestWithAuthInterceptor({
+                    baseURL: siteURL,
+                    serviceToken: tokenObj.serviceToken
                 }),
                 cacheTTL
             }

--- a/src/helpers/client.ts
+++ b/src/helpers/client.ts
@@ -7,7 +7,7 @@ import {
     DeleteOptions
 } from '../types/InfisicalClient';
 import { SecretService } from '../services';
-import { ISecretBundle, Scope } from '../types/models';
+import { ISecretBundle } from '../types/models';
 
 export async function getSecretHelper(instance: InfisicalClient, secretName: string, options: GetOptions): Promise<ISecretBundle> {
     const cacheKey = `${options.type}-${secretName}`;
@@ -35,7 +35,6 @@ export async function getSecretHelper(instance: InfisicalClient, secretName: str
                 return cachedSecret;
             }
         }
-
         const secretBundle = await SecretService.getDecryptedSecret({
             apiRequest: instance.clientConfig.apiRequest,
             workspaceKey: instance.clientConfig.workspaceConfig.workspaceKey,
@@ -82,7 +81,6 @@ export async function getAllSecretsHelper(instance: InfisicalClient, options: Ge
             environment: options.environment,
             path: options.path,
             includeImports: options.includeImports
-
         });
 
         secretBundles.forEach((secretBundle) => {

--- a/src/helpers/key.ts
+++ b/src/helpers/key.ts
@@ -1,24 +1,61 @@
-import { getServiceTokenData } from '../api';
-import { decryptSymmetric128BitHexKeyUTF8 } from '../utils/crypto';
+import { AuthMode } from "../variables";
 import { 
-    ServiceTokenClientConfig, 
+    getServiceTokenData,
+    getServiceTokenDataKey
+} from '../api';
+import { 
+    decryptSymmetric128BitHexKeyUTF8,
+    decryptAsymmetric
+} from '../utils/crypto';
+import { 
+    ClientConfig,
     WorkspaceConfig
 } from '../types/InfisicalClient';
 
-export const populateClientWorkspaceConfigsHelper = async (clientConfig: ServiceTokenClientConfig): Promise<WorkspaceConfig> => {
-    const serviceTokenData = await getServiceTokenData({
-        apiRequest: clientConfig.apiRequest
-    });
+export const populateClientWorkspaceConfigsHelper = async (clientConfig: ClientConfig): Promise<WorkspaceConfig> => {
+    switch (clientConfig.authMode) {
+        case AuthMode.SERVICE_TOKEN: {
+            const serviceTokenData = await getServiceTokenData({
+                apiRequest: clientConfig.apiRequest
+            });
 
-    const workspaceKey = decryptSymmetric128BitHexKeyUTF8({
-        ciphertext: serviceTokenData.encryptedKey,
-        iv: serviceTokenData.iv,
-        tag: serviceTokenData.tag,
-        key: clientConfig.credentials.serviceTokenKey
-    });
+            const workspaceKey = decryptSymmetric128BitHexKeyUTF8({
+                ciphertext: serviceTokenData.encryptedKey,
+                iv: serviceTokenData.iv,
+                tag: serviceTokenData.tag,
+                key: clientConfig.credentials.serviceTokenKey
+            });
+            
+            return ({
+                workspaceId: serviceTokenData.workspace,
+                workspaceKey
+            });
+        }
+        case AuthMode.SERVICE_TOKEN_V3: {
+            const {
+                key: {
+                    workspace,
+                    encryptedKey,
+                    nonce,
+                    publicKey
+                }
+            } = await getServiceTokenDataKey({
+                apiRequest: clientConfig.apiRequest
+            });
+            
+            const workspaceKey = decryptAsymmetric({
+                ciphertext: encryptedKey,
+                nonce,
+                publicKey,
+                privateKey: clientConfig.credentials.privateKey
+            });
+            
+            return ({
+                workspaceId: workspace,
+                workspaceKey
+            });
+        }
+    }
     
-    return ({
-        workspaceId: serviceTokenData.workspace,
-        workspaceKey
-    });
+    throw Error("Failed to populate workspace config");
 }

--- a/src/services/SecretService.ts
+++ b/src/services/SecretService.ts
@@ -18,14 +18,15 @@ import {
     populateClientWorkspaceConfigsHelper
 } from '../helpers/key';
 
-import { ServiceTokenClientConfig } from '../types/InfisicalClient';
+
+import { ClientConfig } from '../types/InfisicalClient';
 
 /**
  * Class for secret-related actions
  */
 export default class SecretService {
     
-    static async populateClientWorkspaceConfig(clientConfig: ServiceTokenClientConfig) {
+    static async populateClientWorkspaceConfig(clientConfig: ClientConfig) {
         return await populateClientWorkspaceConfigsHelper(clientConfig);
     }
 

--- a/src/types/InfisicalClient.d.ts
+++ b/src/types/InfisicalClient.d.ts
@@ -1,7 +1,8 @@
 import { AxiosInstance } from 'axios';
 
 export interface InfisicalClientOptions {
-    token?: string | undefined;
+    token?: string;
+    tokenJson?: string;
     siteURL?: string;
     debug?: boolean;
     cacheTTL?: number;
@@ -16,27 +17,31 @@ interface ServiceTokenCredentials {
     serviceTokenKey: string;
 }
 
-interface ServiceAccountCredentials {
-    serviceAccountPublicKey: string;
-    serviceAccountPrivateKey: string;
-}
-
-interface ClientConfig {
+interface BaseConfig {
     apiRequest: AxiosInstance;
     cacheTTL: number;
 }
 
-export interface ServiceTokenClientConfig extends ClientConfig {
-    authMode: 'serviceToken';
+export interface ServiceTokenClientConfig extends BaseConfig {
+    authMode: "serviceToken"; // TODO: convert to enum
     credentials: ServiceTokenCredentials;
     workspaceConfig?: WorkspaceConfig;
 }
 
-export interface ServiceAccountClientConfig extends ClientConfig {
-    authMode: 'serviceAccount';
-    credentials: ServiceAccountCredentials;
-    workspaceConfig?: WorkspaceConfig[];
+interface ServiceTokenV3Credentials {
+    publicKey: string;
+    privateKey: string;
 }
+
+export interface ServiceTokenV3ClientConfig extends BaseConfig {
+    authMode: "serviceTokenV3"; // TODO: convert to enum
+    credentials: ServiceTokenV3Credentials;
+    workspaceConfig?: WorkspaceConfig;
+}
+
+export type ClientConfig =
+    | ServiceTokenClientConfig
+    | ServiceTokenV3ClientConfig;
 
 type SecretType = 'shared' | 'personal'
 

--- a/src/types/models.d.ts
+++ b/src/types/models.d.ts
@@ -51,3 +51,13 @@ export interface Scope {
     envSlug: string;
     path: string
 }
+
+export interface ServiceTokenDataKeyRes {
+    key: {
+        _id: string;    
+        workspace: string;
+        encryptedKey: string;
+        publicKey: string;
+        nonce: string;
+    }
+}

--- a/src/utils/crypto.ts
+++ b/src/utils/crypto.ts
@@ -55,12 +55,18 @@ export const encryptAsymmetric = ({ plaintext, publicKey, privateKey }: IEncrypt
  * @param {String} obj.privateKey - private key of the receiver (current user)
  * @param {String} plaintext - UTF8 plaintext
  */
-export const decryptAsymmetric = ({ ciphertext, nonce, publicKey, privateKey }: IDecryptAsymmetricInput) => nacl.box.open(
+export const decryptAsymmetric = ({ ciphertext, nonce, publicKey, privateKey }: IDecryptAsymmetricInput) => {
+    const plaintext: Uint8Array | null = nacl.box.open(
         util.decodeBase64(ciphertext),
         util.decodeBase64(nonce),
         util.decodeBase64(publicKey),
         util.decodeBase64(privateKey)
-);
+    );
+    
+    if (plaintext == null) throw Error("Invalid ciphertext or keys");
+    
+    return util.encodeUTF8(plaintext);
+}
 
 /**
  * Return new base64-encoded, 256-bit symmetric key 

--- a/src/variables/index.ts
+++ b/src/variables/index.ts
@@ -1,5 +1,12 @@
+
+
 export const INFISICAL_URL = 'https://app.infisical.com';
-export const AUTH_MODE_SERVICE_TOKEN = 'serviceToken';
+
+export enum AuthMode {
+    SERVICE_TOKEN = "serviceToken",
+    SERVICE_TOKEN_V3 = "serviceTokenV3"
+}
+
 export const ALGORITHM_AES_256_GCM = 'aes-256-gcm';
 export const IV_BYTES_SIZE = 12;
 export const SYMMETRIC_KEY_BYTES_SIZE = 32;

--- a/tests/client/InfisicalClient.test.ts
+++ b/tests/client/InfisicalClient.test.ts
@@ -7,6 +7,7 @@ describe('InfisicalClient', () => {
     beforeAll(async () => {
         client = new InfisicalClient({
             token: process.env.INFISICAL_TOKEN!,
+            tokenJson: process.env.INFISICAL_TOKEN_JSON!,
             siteURL: process.env.SITE_URL!,
             debug: true
         });


### PR DESCRIPTION
This PR adds support for the Service Token V3 (Beta) authentication method for Infisical which is a JSON; note that it continues to support Service Token V2 (the default authentication method at this time). With this update, it's possible to initialize the InfisicalClient with a Service Token V3 JSON via the `tokenJSON` parameter to perform CRUD secret operations.

More details for ST V3 [here](https://github.com/Infisical/infisical/pull/1027).