### PR TITLE
Fix: Add secret referencing

### DIFF
--- a/server.js
+++ b/server.js
@@ -1,0 +1,36 @@
+// development test file only
+
+require('dotenv').config();
+import InfisicalClient from "./lib";
+
+const config = {
+  token: process.env.INFISICAL_TOKEN,
+};
+
+async function fetchData() {
+  try {
+    const client = new InfisicalClient(config);
+
+    const secrets = await client.getAllSecrets({
+      environment: "dev",
+      path: "/",
+      attachToProcessEnv: false,
+      includeImports: true,
+    });
+
+    console.log("secrets:", secrets);
+
+    // const secret = await client.getSecret("FULL_HOST", {
+    //   environment: "dev",
+    //   path: "/",
+    //   type: "shared",
+    // });
+
+    // // console.log("secret:", secret);
+
+  } catch (err) {
+    console.error("Error fetching data:", err);
+  }
+}
+
+fetchData();

--- a/src/helpers/expandSecrets.ts
+++ b/src/helpers/expandSecrets.ts
@@ -1,0 +1,179 @@
+import path from "path";
+
+import { decryptSymmetric128BitHexKeyUTF8 } from "../utils/crypto";
+import { getSecrets } from "../api";
+import { AxiosInstance } from "../types/api";
+
+interface FetchSecretsCrossEnvParams {
+    apiRequest: AxiosInstance;
+    workspaceId: string;
+    environment: string;
+    workspaceKey: string;
+    secretPath: string;
+    includeImports: boolean;
+}
+
+const fetchSecretsCrossEnv = ({
+    apiRequest,
+    workspaceId,
+    environment,
+    workspaceKey,
+    secretPath,
+    includeImports,
+}: FetchSecretsCrossEnvParams) => {
+
+  const fetchCache: Record<string, Record<string, string>> = {};
+
+  return async (secRefEnv: string, secRefPath: string[], secRefKey: string) => {
+    const secRefPathUrl = path.join("/", ...secRefPath);
+    const uniqKey = `${secRefEnv}-${secRefPathUrl}`;
+
+    if (fetchCache?.[uniqKey]) {
+      return fetchCache[uniqKey][secRefKey];
+    }
+
+    const { secrets } = await getSecrets(apiRequest, {
+        workspaceId,
+        environment,
+        path: secretPath,
+        includeImports
+    });
+
+    const decryptedSec = secrets.reduce<Record<string, string>>((prev, secret) => {
+      const secretKey = decryptSymmetric128BitHexKeyUTF8({
+        ciphertext: secret.secretKeyCiphertext,
+        iv: secret.secretKeyIV,
+        tag: secret.secretKeyTag,
+        key: workspaceKey
+      });
+      const secretValue = decryptSymmetric128BitHexKeyUTF8({
+        ciphertext: secret.secretValueCiphertext,
+        iv: secret.secretValueIV,
+        tag: secret.secretValueTag,
+        key: workspaceKey
+      });
+
+      prev[secretKey] = secretValue;
+      return prev;
+    }, {});
+
+    fetchCache[uniqKey] = decryptedSec;
+
+    return fetchCache[uniqKey][secRefKey];
+  };
+};
+
+const INTERPOLATION_SYNTAX_REG = new RegExp(/\${([^}]+)}/g);
+
+const recursivelyExpandSecret = async (
+  expandedSec: Record<string, string>,
+  interpolatedSec: Record<string, string>,
+  fetchCrossEnv: (secRefEnv: string, secRefPath: string[], secRefKey: string) => Promise<string>,
+  recursionChainBreaker: Record<string, boolean>,
+  key: string
+) => {
+  if (expandedSec?.[key]) return expandedSec[key];
+  if (recursionChainBreaker?.[key]) return "";
+
+  recursionChainBreaker[key] = true;
+  let interpolatedValue = interpolatedSec[key];
+
+  if (!interpolatedValue) {
+    // eslint-disable-next-line no-console
+    // console.error(`Couldn't find referenced value - ${key}`);
+    return "";
+  }
+
+  const refs = interpolatedValue.match(INTERPOLATION_SYNTAX_REG);
+
+  if (refs) {
+    const resolvedValues = [];
+
+    for (const interpolationSyntax of refs) {
+      const interpolationKey = interpolationSyntax.slice(2, -1);
+
+      const val = await recursivelyExpandSecret(
+        expandedSec,
+        interpolatedSec,
+        fetchCrossEnv,
+        recursionChainBreaker,
+        interpolationKey
+      );
+
+      if (val) resolvedValues.push({ interpolationSyntax, val });
+    }
+
+    resolvedValues.forEach(({ interpolationSyntax, val }) => {
+      const regex = new RegExp(interpolationSyntax.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'), 'g');
+      interpolatedValue = interpolatedValue.replace(regex, val);
+    });
+  }
+
+  expandedSec[key] = interpolatedValue;
+  return interpolatedValue;
+};
+
+// used to convert multi line ones to quotes ones with \n
+const formatMultiValueEnv = (val?: string) => {
+  if (!val) return "";
+  if (!val.match("\n")) return val;
+  return `"${val.replace(/\n/g, "\\n")}"`;
+};
+
+export const expandSecrets = async (
+  workspaceId: string,
+  workspaceKey: string,
+  apiRequest: AxiosInstance,
+  environment: string,
+  secretPath: string,
+  secrets: Record<string, { value: string; comment?: string; skipMultilineEncoding?: boolean }>,
+  includeImports?: boolean
+) => {
+
+  const expandedSec: Record<string, string> = {};
+  const interpolatedSec: Record<string, string> = {};
+
+  const crossSecEnvFetch = fetchSecretsCrossEnv({
+    workspaceId,
+    workspaceKey, 
+    apiRequest, 
+    environment, 
+    secretPath, 
+    includeImports: includeImports ? includeImports : false
+  });
+
+  Object.keys(secrets).forEach((key) => {
+    if (secrets[key].value.match(INTERPOLATION_SYNTAX_REG)) {
+      interpolatedSec[key] = secrets[key].value;
+    } else {
+      expandedSec[key] = secrets[key].value;
+    }
+  });
+
+  for (const key of Object.keys(secrets)) {
+    if (expandedSec?.[key]) {
+      // should not do multi line encoding if user has set it to skip
+      secrets[key].value = secrets[key].skipMultilineEncoding
+        ? expandedSec[key]
+        : formatMultiValueEnv(expandedSec[key]);
+      continue;
+    }
+
+    // this is to avoid recursion loop. So the graph should be direct graph rather than cyclic
+    // so for any recursion building if there is an entity two times same key meaning it will be looped
+    const recursionChainBreaker: Record<string, boolean> = {};
+    const expandedVal = await recursivelyExpandSecret(
+      expandedSec,
+      interpolatedSec,
+      crossSecEnvFetch,
+      recursionChainBreaker,
+      key
+    );
+
+    secrets[key].value = secrets[key].skipMultilineEncoding
+      ? expandedVal
+      : formatMultiValueEnv(expandedVal);
+  }
+
+  return secrets;
+};


### PR DESCRIPTION
Currently the Node SDK doesn't support secret referencing eg. 

```
NESTED_SECRET_1 = ${NESTED_SECRET_2}
NESTED_SECRET_2 = ${NESTED_SECRET_3}
NESTED_SECRET_3 = DEEPLY_NESTED_SECRET
```

All of these should resolve to "DEEPLY_NESTED_SECRET".

Still a WIP.

TODO: 
- Fix getSecret
- Fix secret references from other folders & environments eg.

`MONGO_URL = mongodb://${dev.db-secrets.USERNAME}:${dev.db-secrets.PASSWORD}@hostname:${dev.db-secrets.PORT}/prod`

This should resolve to a usable Mongo connection string.