### PR TITLE
feat: folder endpoints

### DIFF
--- a/src/api/folders/index.ts
+++ b/src/api/folders/index.ts
@@ -1,0 +1,1 @@
+export { listFolders, createFolder, updateFolder, deleteFolder } from "./queries";

--- a/src/api/folders/queries.ts
+++ b/src/api/folders/queries.ts
@@ -1,0 +1,57 @@
+import { AxiosInstance } from "axios";
+import { CreateFolderDTO, DeleteFolderDTO, ListFoldersDTO, UpdateFolderDTO } from "../../types/api";
+import { IFolder, IFolderWithVersion } from "../../types/models";
+
+export const listFolders = async (apiRequest: AxiosInstance, options: ListFoldersDTO) => {
+  const {
+    data: { folders },
+  } = await apiRequest.get<{ folders: IFolder[] }>("/api/v1/folders", {
+    params: {
+      directory: options.directory,
+      workspaceId: options.workspaceId,
+      environment: options.environment,
+    },
+  });
+
+  return folders;
+};
+
+export const createFolder = async (apiRequest: AxiosInstance, options: CreateFolderDTO) => {
+  const {
+    data: { folder },
+  } = await apiRequest.post<{ folder: IFolderWithVersion }>("/api/v1/folders", {
+    directory: options.directory,
+    environment: options.environment,
+    folderName: options.folderName,
+    workspaceId: options.workspaceId,
+  });
+
+  return folder;
+};
+
+export const updateFolder = async (apiRequest: AxiosInstance, options: UpdateFolderDTO) => {
+  const {
+    data: { folder, message },
+  } = await apiRequest.patch<{ folder: IFolder; message: string }>(`/api/v1/folders/${options.folderName}`, {
+    name: options.name,
+    directory: options.directory,
+    environment: options.environment,
+    workspaceId: options.workspaceId,
+  });
+
+  return { folder, message };
+};
+
+export const deleteFolder = async (apiRequest: AxiosInstance, options: DeleteFolderDTO) => {
+  const {
+    data: { folders, message },
+  } = await apiRequest.delete<{ folders: IFolder[]; message: string }>(`/api/v1/folders/${options.folderName}`, {
+    data: {
+      directory: options.directory,
+      environment: options.environment,
+      workspaceId: options.workspaceId,
+    },
+  });
+
+  return { folders, message };
+};

--- a/src/api/secrets/index.ts
+++ b/src/api/secrets/index.ts
@@ -1,7 +1,1 @@
-export {
-    getSecrets,
-    getSecret,
-    createSecret,
-    updateSecret,
-    deleteSecret
-} from './queries';
+export { getSecrets, getSecret, createSecret, updateSecret, deleteSecret } from "./queries";

--- a/src/client/InfisicalClient.ts
+++ b/src/client/InfisicalClient.ts
@@ -1,219 +1,269 @@
-import { 
-    INFISICAL_URL, 
-    AuthMode,
-} from '../variables';
-import { createApiRequestWithAuthInterceptor } from '../api';
-import { ISecretBundle } from '../types/models';
+import { INFISICAL_URL, AuthMode } from "../variables";
+import { createApiRequestWithAuthInterceptor } from "../api";
+import { IFolder, ISecretBundle } from "../types/models";
 import {
-    ClientConfig,
-    GetAllOptions,
-    GetOptions,
-    CreateOptions,
-    UpdateOptions,
-    DeleteOptions,
-    InfisicalClientOptions
-} from '../types/InfisicalClient';
+  ClientConfig,
+  GetAllOptions,
+  GetOptions,
+  CreateOptions,
+  UpdateOptions,
+  DeleteOptions,
+  InfisicalClientOptions,
+  FolderOptions,
+} from "../types/InfisicalClient";
+import { IEncryptSymmetricOutput } from "../types/utils";
 import {
-    IDecryptSymmetricInput,
-    IEncryptSymmetricOutput
-} from '../types/utils';
-import {
-    getAllSecretsHelper,
-    getSecretHelper,
-    createSecretHelper,
-    updateSecretHelper,
-    deleteSecretHelper
-} from '../helpers/client';
-import {
-    createSymmetricKey,
-    encryptSymmetric,
-    decryptSymmetric
-} from '../utils/crypto';
+  getAllSecretsHelper,
+  getSecretHelper,
+  createSecretHelper,
+  updateSecretHelper,
+  deleteSecretHelper,
+  listFoldersHelper,
+  createFolderHelper,
+  updateFolderHelper,
+  deleteFolderHelper,
+} from "../helpers/client";
+import { createSymmetricKey, encryptSymmetric, decryptSymmetric } from "../utils/crypto";
 
 class InfisicalClient {
+  public cache: { [key: string]: ISecretBundle } = {};
 
-    public cache: { [key: string]: ISecretBundle } = {}
+  public clientConfig: ClientConfig | undefined = undefined;
+  public debug: boolean = false;
 
-    public clientConfig: ClientConfig | undefined = undefined;
-    public debug: boolean = false;
+  /**
+   * Create an instance of the Infisical client
+   * @param {Object} obj
+   * @param {String} obj.token - an Infisical Token scoped to a project and environment
+   * @param {Boolean} debug - whether debug is on
+   * @param {Number} cacheTTL - time-to-live (in seconds) for refreshing cached secrets.
+   */
+  constructor({
+    token = undefined,
+    tokenJson = undefined,
+    siteURL = INFISICAL_URL,
+    debug = false,
+    cacheTTL = 300,
+  }: InfisicalClientOptions) {
+    if (token && token !== "") {
+      const lastDotIdx = token.lastIndexOf(".");
+      const serviceToken = token.substring(0, lastDotIdx);
 
-    /**
-     * Create an instance of the Infisical client
-     * @param {Object} obj
-     * @param {String} obj.token - an Infisical Token scoped to a project and environment
-     * @param {Boolean} debug - whether debug is on
-     * @param {Number} cacheTTL - time-to-live (in seconds) for refreshing cached secrets.
-     */
-    constructor({
-        token = undefined,
-        tokenJson = undefined,
-        siteURL = INFISICAL_URL,
-        debug = false,
-        cacheTTL = 300
-    }: InfisicalClientOptions) {
-        if (token && token !== '') {
-            const lastDotIdx = token.lastIndexOf('.');
-            const serviceToken = token.substring(0, lastDotIdx);
-
-            this.clientConfig = {
-                authMode: AuthMode.SERVICE_TOKEN,
-                credentials: {
-                    serviceTokenKey: token.substring(lastDotIdx + 1)
-                },
-                apiRequest: createApiRequestWithAuthInterceptor({
-                    baseURL: siteURL,
-                    serviceToken
-                }),
-                cacheTTL
-            }
-        }
-        
-        if (tokenJson && tokenJson !== "") {
-            const tokenObj = JSON.parse(tokenJson);
-            
-            this.clientConfig = {
-                authMode: AuthMode.SERVICE_TOKEN_V3,
-                credentials: {
-                    publicKey: tokenObj.publicKey,
-                    privateKey: tokenObj.privateKey
-                },
-                apiRequest: createApiRequestWithAuthInterceptor({
-                    baseURL: siteURL,
-                    serviceToken: tokenObj.serviceToken
-                }),
-                cacheTTL
-            }
-        }
-
-        this.debug = debug;
+      this.clientConfig = {
+        authMode: AuthMode.SERVICE_TOKEN,
+        credentials: {
+          serviceTokenKey: token.substring(lastDotIdx + 1),
+        },
+        apiRequest: createApiRequestWithAuthInterceptor({
+          baseURL: siteURL,
+          serviceToken,
+        }),
+        cacheTTL,
+      };
     }
 
-    /**
-    * Return all the secrets accessible by the instance of Infisical
-    */
-    public async getAllSecrets(
-        options: GetAllOptions = {
-            environment: "dev",
-            path: "/",
-            attachToProcessEnv: false,
-            includeImports: true
-        }
-    ): Promise<ISecretBundle[]> {
-        return await getAllSecretsHelper(this, options);
+    if (tokenJson && tokenJson !== "") {
+      const tokenObj = JSON.parse(tokenJson);
+
+      this.clientConfig = {
+        authMode: AuthMode.SERVICE_TOKEN_V3,
+        credentials: {
+          publicKey: tokenObj.publicKey,
+          privateKey: tokenObj.privateKey,
+        },
+        apiRequest: createApiRequestWithAuthInterceptor({
+          baseURL: siteURL,
+          serviceToken: tokenObj.serviceToken,
+        }),
+        cacheTTL,
+      };
     }
 
-    /**
-     * Return secret with name [secretName]
-     * @returns {ISecretBundle} secretBundle - secret bundle
-     * @param secretName name of the secret
-     * @param options - secret selection options
-     * @returns - a promise representing the result of the asynchronous get
-     */
-    public async getSecret(
-        secretName: string,
-        options: GetOptions = {
-            type: "personal",
-            environment: "dev",
-            path: "/"
-        }
-    ): Promise<ISecretBundle> {
-        return await getSecretHelper(this, secretName, options);
-    }
+    this.debug = debug;
+  }
 
-    /**
-     * Create secret with name [secretName] and value [secretValue]
-     * @param secretName - name of secret to create
-     * @param secretValue - value of secret to create
-     * @param options - secret selection options
-     * @returns - a promise representing the result of the asynchronous creation
-     */
-    public async createSecret(
-        secretName: string,
-        secretValue: string,
-        options: CreateOptions = {
-            environment: "dev",
-            type: "shared",
-            path: "/"
-        }
-    ): Promise<ISecretBundle> {
-        return await createSecretHelper(this, secretName, secretValue, options);
+  /**
+   * Return all the secrets accessible by the instance of Infisical
+   */
+  public async getAllSecrets(
+    options: GetAllOptions = {
+      environment: "dev",
+      path: "/",
+      attachToProcessEnv: false,
+      includeImports: true,
     }
+  ): Promise<ISecretBundle[]> {
+    return await getAllSecretsHelper(this, options);
+  }
 
-    /**
-     * Update secret with name [secretName] and value [secretValue]
-     * @param secretName - name of secret to update
-     * @param secretValue - new value for secret
-     * @param options - secret selection options
-     * @returns - a promise representing the result of the asynchronous update
-     */
-    public async updateSecret(
-        secretName: string,
-        secretValue: string,
-        options: UpdateOptions = {
-            type: "shared",
-            environment: "dev",
-            path: "/"
-        }
-    ): Promise<ISecretBundle> {
-        return await updateSecretHelper(this, secretName, secretValue, options);
+  /**
+   * Return secret with name [secretName]
+   * @returns {ISecretBundle} secretBundle - secret bundle
+   * @param secretName name of the secret
+   * @param options - secret selection options
+   * @returns - a promise representing the result of the asynchronous get
+   */
+  public async getSecret(
+    secretName: string,
+    options: GetOptions = {
+      type: "personal",
+      environment: "dev",
+      path: "/",
     }
+  ): Promise<ISecretBundle> {
+    return await getSecretHelper(this, secretName, options);
+  }
 
-    /**
-     * Delete secret with name [secretName]
-     * @param secretName - name of secret to delete
-     * @param options - secret selection options
-     * @returns - a promise representing the result of the asynchronous deletion
-     */
-    public async deleteSecret(
-        secretName: string,
-        options: DeleteOptions = {
-            environment: "dev",
-            type: "shared",
-            path: "/"
-        }
-    ): Promise<ISecretBundle> {
-        return await deleteSecretHelper(this, secretName, options);
+  /**
+   * Create secret with name [secretName] and value [secretValue]
+   * @param secretName - name of secret to create
+   * @param secretValue - value of secret to create
+   * @param options - secret selection options
+   * @returns - a promise representing the result of the asynchronous creation
+   */
+  public async createSecret(
+    secretName: string,
+    secretValue: string,
+    options: CreateOptions = {
+      environment: "dev",
+      type: "shared",
+      path: "/",
     }
+  ): Promise<ISecretBundle> {
+    return await createSecretHelper(this, secretName, secretValue, options);
+  }
 
-    /**
-     * Create a base64-encoded, 256-bit symmetric key
-     * @returns {String} key - the symmetric key
-     */
-    public createSymmetricKey(): string {
-        return createSymmetricKey();
+  /**
+   * Update secret with name [secretName] and value [secretValue]
+   * @param secretName - name of secret to update
+   * @param secretValue - new value for secret
+   * @param options - secret selection options
+   * @returns - a promise representing the result of the asynchronous update
+   */
+  public async updateSecret(
+    secretName: string,
+    secretValue: string,
+    options: UpdateOptions = {
+      type: "shared",
+      environment: "dev",
+      path: "/",
     }
+  ): Promise<ISecretBundle> {
+    return await updateSecretHelper(this, secretName, secretValue, options);
+  }
 
-    /**
-     * Encrypt the plaintext [plaintext] with the (base64) 256-bit
-     * secret key [key]
-     * @param plaintext 
-     * @param key - base64-encoded, 256-bit symmetric key
-     * @returns {IEncryptSymmetricOutput} - an object containing the base64-encoded ciphertext, iv, and tag
-     */
-    public encryptSymmetric(plaintext: string, key: string): IEncryptSymmetricOutput {
-        return encryptSymmetric({
-            plaintext,
-            key,
-        });
+  /**
+   * Delete secret with name [secretName]
+   * @param secretName - name of secret to delete
+   * @param options - secret selection options
+   * @returns - a promise representing the result of the asynchronous deletion
+   */
+  public async deleteSecret(
+    secretName: string,
+    options: DeleteOptions = {
+      environment: "dev",
+      type: "shared",
+      path: "/",
     }
+  ): Promise<ISecretBundle> {
+    return await deleteSecretHelper(this, secretName, options);
+  }
 
-    /**
-     * Decrypt the ciphertext [ciphertext] with the (base64) 256-bit
-     * secret key [key], provided [iv] and [tag]
-     * @param ciphertext - base64-encoded ciphertext
-     * @param key - base64-encoded, 256-bit symmetric key
-     * @param iv - base64-encoded initialization vector
-     * @param tag - base64-encoded authentication tag
-     * @returns {String} - the decrypted [ciphertext] or cleartext
-     */
-    public decryptSymmetric(ciphertext: string, key: string, iv: string, tag: string): string {
-        return decryptSymmetric({
-            ciphertext,
-            iv,
-            tag,
-            key
-        })
+  /**
+   * Return all the folders in a directory
+   */
+  public async listFolders(
+    options: FolderOptions = {
+      environment: "dev",
+      directory: "/",
     }
+  ): Promise<IFolder[]> {
+    return await listFoldersHelper(this, options);
+  }
+
+  /**
+   * Creates a folder in a directory
+   */
+  public async createFolder(
+    folderName: string,
+    options: FolderOptions = {
+      environment: "dev",
+      directory: "/",
+    }
+  ): Promise<IFolder | null> {
+    return await createFolderHelper(this, folderName, options);
+  }
+
+  /**
+   * Updates the name of a folder
+   */
+  public async updateFolder(
+    name: string,
+    newName: string,
+    options: FolderOptions = {
+      environment: "dev",
+      directory: "/",
+    }
+  ): Promise<IFolder | null> {
+    return await updateFolderHelper(this, name, newName, options);
+  }
+
+  /**
+   * Deletes a folder in a specified directory
+   */
+  public async deleteFolder(
+    folderName: string,
+    options: FolderOptions = {
+      environment: "/",
+      directory: "/",
+    }
+  ): Promise<IFolder[] | null> {
+    return await deleteFolderHelper(this, folderName, {
+      ...options,
+      environment: "dev",
+      directory: "/",
+    });
+  }
+
+  /**
+   * Create a base64-encoded, 256-bit symmetric key
+   * @returns {String} key - the symmetric key
+   */
+  public createSymmetricKey(): string {
+    return createSymmetricKey();
+  }
+
+  /**
+   * Encrypt the plaintext [plaintext] with the (base64) 256-bit
+   * secret key [key]
+   * @param plaintext
+   * @param key - base64-encoded, 256-bit symmetric key
+   * @returns {IEncryptSymmetricOutput} - an object containing the base64-encoded ciphertext, iv, and tag
+   */
+  public encryptSymmetric(plaintext: string, key: string): IEncryptSymmetricOutput {
+    return encryptSymmetric({
+      plaintext,
+      key,
+    });
+  }
+
+  /**
+   * Decrypt the ciphertext [ciphertext] with the (base64) 256-bit
+   * secret key [key], provided [iv] and [tag]
+   * @param ciphertext - base64-encoded ciphertext
+   * @param key - base64-encoded, 256-bit symmetric key
+   * @param iv - base64-encoded initialization vector
+   * @param tag - base64-encoded authentication tag
+   * @returns {String} - the decrypted [ciphertext] or cleartext
+   */
+  public decryptSymmetric(ciphertext: string, key: string, iv: string, tag: string): string {
+    return decryptSymmetric({
+      ciphertext,
+      iv,
+      tag,
+      key,
+    });
+  }
 }
 
 export default InfisicalClient;

--- a/src/helpers/client.ts
+++ b/src/helpers/client.ts
@@ -1,216 +1,323 @@
-import InfisicalClient from '../client/InfisicalClient';
+import InfisicalClient from "../client/InfisicalClient";
 import {
-    GetAllOptions,
-    GetOptions,
-    CreateOptions,
-    UpdateOptions,
-    DeleteOptions
-} from '../types/InfisicalClient';
-import { SecretService } from '../services';
-import { ISecretBundle } from '../types/models';
+  GetAllOptions,
+  GetOptions,
+  CreateOptions,
+  UpdateOptions,
+  DeleteOptions,
+  FolderOptions,
+} from "../types/InfisicalClient";
+import { SecretService } from "../services";
+import { IFolder, ISecretBundle } from "../types/models";
+import { createFolder, deleteFolder, listFolders, updateFolder } from "../api/folders";
 
-export async function getSecretHelper(instance: InfisicalClient, secretName: string, options: GetOptions): Promise<ISecretBundle> {
-    const cacheKey = `${options.type}-${secretName}`;
-    let cachedSecret: ISecretBundle | undefined = undefined;
-    try {
-        if (!instance.clientConfig) throw Error('Failed to find client config');
+export async function getSecretHelper(
+  instance: InfisicalClient,
+  secretName: string,
+  options: GetOptions
+): Promise<ISecretBundle> {
+  const cacheKey = `${options.type}-${secretName}`;
+  let cachedSecret: ISecretBundle | undefined = undefined;
+  try {
+    if (!instance.clientConfig) throw Error("Failed to find client config");
 
-        if (!instance.clientConfig.workspaceConfig) {
-            instance.clientConfig.workspaceConfig = await SecretService.populateClientWorkspaceConfig(instance.clientConfig);
-        }
-
-        cachedSecret = instance.cache[cacheKey];
-
-        if (cachedSecret) {
-
-            const currentTime = new Date();
-            const cacheExpiryTime = cachedSecret.lastFetchedAt;
-            cacheExpiryTime.setSeconds(cacheExpiryTime.getSeconds() + instance.clientConfig.cacheTTL);
-
-            if (currentTime < cacheExpiryTime) {
-                if (instance.debug) {
-                    console.log(`Returning cached secret: ${cachedSecret.secretName}`)
-                }
-
-                return cachedSecret;
-            }
-        }
-        const secretBundle = await SecretService.getDecryptedSecret({
-            apiRequest: instance.clientConfig.apiRequest,
-            workspaceKey: instance.clientConfig.workspaceConfig.workspaceKey,
-            secretName,
-            workspaceId: instance.clientConfig.workspaceConfig?.workspaceId,
-            environment: options.environment,
-            path: options.path,
-            type: options.type
-        });
-
-        instance.cache[`${secretBundle.type}-${secretBundle.secretName}`] = secretBundle;
-
-        return secretBundle;
-
-    } catch (err) {
-        if (instance.debug) console.error(err);
-
-        if (cachedSecret) {
-            if (instance.debug) {
-                console.log(`Returning cached secret: ${cachedSecret}`);
-            }
-
-            return cachedSecret;
-        }
-
-        return await SecretService.getFallbackSecret({
-            secretName
-        });
+    if (!instance.clientConfig.workspaceConfig) {
+      instance.clientConfig.workspaceConfig = await SecretService.populateClientWorkspaceConfig(instance.clientConfig);
     }
+
+    cachedSecret = instance.cache[cacheKey];
+
+    if (cachedSecret) {
+      const currentTime = new Date();
+      const cacheExpiryTime = cachedSecret.lastFetchedAt;
+      cacheExpiryTime.setSeconds(cacheExpiryTime.getSeconds() + instance.clientConfig.cacheTTL);
+
+      if (currentTime < cacheExpiryTime) {
+        if (instance.debug) {
+          console.log(`Returning cached secret: ${cachedSecret.secretName}`);
+        }
+
+        return cachedSecret;
+      }
+    }
+    const secretBundle = await SecretService.getDecryptedSecret({
+      apiRequest: instance.clientConfig.apiRequest,
+      workspaceKey: instance.clientConfig.workspaceConfig.workspaceKey,
+      secretName,
+      workspaceId: instance.clientConfig.workspaceConfig.workspaceId,
+      environment: options.environment,
+      path: options.path,
+      type: options.type,
+    });
+
+    instance.cache[`${secretBundle.type}-${secretBundle.secretName}`] = secretBundle;
+
+    return secretBundle;
+  } catch (err) {
+    if (instance.debug) console.error(err);
+
+    if (cachedSecret) {
+      if (instance.debug) {
+        console.log(`Returning cached secret: ${cachedSecret}`);
+      }
+
+      return cachedSecret;
+    }
+
+    return await SecretService.getFallbackSecret({
+      secretName,
+    });
+  }
 }
 
 export async function getAllSecretsHelper(instance: InfisicalClient, options: GetAllOptions): Promise<ISecretBundle[]> {
-    try {
-        if (!instance.clientConfig) throw Error('Failed to find client config');
+  try {
+    if (!instance.clientConfig) throw Error("Failed to find client config");
 
-        if (!instance.clientConfig.workspaceConfig) {
-            instance.clientConfig.workspaceConfig = await SecretService.populateClientWorkspaceConfig(instance.clientConfig);
-        }
-
-        const secretBundles = await SecretService.getDecryptedSecrets({
-            apiRequest: instance.clientConfig.apiRequest,
-            workspaceKey: instance.clientConfig.workspaceConfig.workspaceKey,
-            workspaceId: instance.clientConfig.workspaceConfig?.workspaceId,
-            environment: options.environment,
-            path: options.path,
-            includeImports: options.includeImports
-        });
-
-        secretBundles.forEach((secretBundle) => {
-            const cacheKey = `${secretBundle.type}-${secretBundle.secretName}`;
-            instance.cache[cacheKey] = secretBundle;
-
-            if (options.attachToProcessEnv) {
-                process.env[secretBundle.secretName] = secretBundle.secretValue;
-            }
-        });
-
-        return secretBundles;
-
-    } catch (err) {
-        if (instance.debug) console.error(err);
-
-        return [await SecretService.getFallbackSecret({
-            secretName: ''
-        })]
+    if (!instance.clientConfig.workspaceConfig) {
+      instance.clientConfig.workspaceConfig = await SecretService.populateClientWorkspaceConfig(instance.clientConfig);
     }
+
+    const secretBundles = await SecretService.getDecryptedSecrets({
+      apiRequest: instance.clientConfig.apiRequest,
+      workspaceKey: instance.clientConfig.workspaceConfig.workspaceKey,
+      workspaceId: instance.clientConfig.workspaceConfig.workspaceId,
+      environment: options.environment,
+      path: options.path,
+      includeImports: options.includeImports,
+    });
+
+    secretBundles.forEach((secretBundle) => {
+      const cacheKey = `${secretBundle.type}-${secretBundle.secretName}`;
+      instance.cache[cacheKey] = secretBundle;
+
+      if (options.attachToProcessEnv) {
+        process.env[secretBundle.secretName] = secretBundle.secretValue;
+      }
+    });
+
+    return secretBundles;
+  } catch (err) {
+    if (instance.debug) console.error(err);
+
+    return [
+      await SecretService.getFallbackSecret({
+        secretName: "",
+      }),
+    ];
+  }
 }
 
 export async function createSecretHelper(
-    instance: InfisicalClient,
-    secretName: string,
-    secretValue: string,
-    options: CreateOptions
+  instance: InfisicalClient,
+  secretName: string,
+  secretValue: string,
+  options: CreateOptions
 ): Promise<ISecretBundle> {
-    try {
-        if (!instance.clientConfig) throw Error('Failed to find client config');
+  try {
+    if (!instance.clientConfig) throw Error("Failed to find client config");
 
-        if (!instance.clientConfig.workspaceConfig) {
-            instance.clientConfig.workspaceConfig = await SecretService.populateClientWorkspaceConfig(instance.clientConfig);
-        }
-
-        const secretBundle = await SecretService.createSecret({
-            apiRequest: instance.clientConfig.apiRequest,
-            workspaceKey: instance.clientConfig.workspaceConfig.workspaceKey,
-            workspaceId: instance.clientConfig.workspaceConfig?.workspaceId,
-            environment: options.environment,
-            path: options.path,
-            type: options.type,
-            secretName,
-            secretValue
-        });
-
-        const cacheKey = `${options.type}-${secretName}`;
-        instance.cache[cacheKey] = secretBundle;
-
-        return secretBundle;
-
-    } catch (err) {
-        if (instance.debug) console.error(err);
-
-        return await SecretService.getFallbackSecret({
-            secretName
-        })
+    if (!instance.clientConfig.workspaceConfig) {
+      instance.clientConfig.workspaceConfig = await SecretService.populateClientWorkspaceConfig(instance.clientConfig);
     }
+
+    const secretBundle = await SecretService.createSecret({
+      apiRequest: instance.clientConfig.apiRequest,
+      workspaceKey: instance.clientConfig.workspaceConfig.workspaceKey,
+      workspaceId: instance.clientConfig.workspaceConfig.workspaceId,
+      environment: options.environment,
+      path: options.path,
+      type: options.type,
+      secretName,
+      secretValue,
+    });
+
+    const cacheKey = `${options.type}-${secretName}`;
+    instance.cache[cacheKey] = secretBundle;
+
+    return secretBundle;
+  } catch (err) {
+    if (instance.debug) console.error(err);
+
+    return await SecretService.getFallbackSecret({
+      secretName,
+    });
+  }
 }
 
 export async function updateSecretHelper(
-    instance: InfisicalClient,
-    secretName: string,
-    secretValue: string,
-    options: UpdateOptions
+  instance: InfisicalClient,
+  secretName: string,
+  secretValue: string,
+  options: UpdateOptions
 ): Promise<ISecretBundle> {
-    try {
-        if (!instance.clientConfig) throw Error('Failed to find client config');
+  try {
+    if (!instance.clientConfig) throw Error("Failed to find client config");
 
-        if (!instance.clientConfig.workspaceConfig) {
-            instance.clientConfig.workspaceConfig = await SecretService.populateClientWorkspaceConfig(instance.clientConfig);
-        }
-
-        const secretBundle = await SecretService.updateSecret({
-            apiRequest: instance.clientConfig.apiRequest,
-            workspaceKey: instance.clientConfig.workspaceConfig.workspaceKey,
-            workspaceId: instance.clientConfig.workspaceConfig?.workspaceId,
-            environment: options.environment,
-            type: options.type,
-            path: options.path,
-            secretName,
-            secretValue
-        });
-
-        const cacheKey = `${options.type}-${secretName}`;
-        instance.cache[cacheKey] = secretBundle;
-
-        return secretBundle;
-
-    } catch (err) {
-        if (instance.debug) console.error(err);
-
-        return await SecretService.getFallbackSecret({
-            secretName
-        })
+    if (!instance.clientConfig.workspaceConfig) {
+      instance.clientConfig.workspaceConfig = await SecretService.populateClientWorkspaceConfig(instance.clientConfig);
     }
+
+    const secretBundle = await SecretService.updateSecret({
+      apiRequest: instance.clientConfig.apiRequest,
+      workspaceKey: instance.clientConfig.workspaceConfig.workspaceKey,
+      workspaceId: instance.clientConfig.workspaceConfig.workspaceId,
+      environment: options.environment,
+      type: options.type,
+      path: options.path,
+      secretName,
+      secretValue,
+    });
+
+    const cacheKey = `${options.type}-${secretName}`;
+    instance.cache[cacheKey] = secretBundle;
+
+    return secretBundle;
+  } catch (err) {
+    if (instance.debug) console.error(err);
+
+    return await SecretService.getFallbackSecret({
+      secretName,
+    });
+  }
 }
 
 export async function deleteSecretHelper(
-    instance: InfisicalClient,
-    secretName: string,
-    options: DeleteOptions
+  instance: InfisicalClient,
+  secretName: string,
+  options: DeleteOptions
 ): Promise<ISecretBundle> {
-    try {
-        if (!instance.clientConfig) throw Error('Failed to find client config');
+  try {
+    if (!instance.clientConfig) throw Error("Failed to find client config");
 
-        if (!instance.clientConfig.workspaceConfig) {
-            instance.clientConfig.workspaceConfig = await SecretService.populateClientWorkspaceConfig(instance.clientConfig);
-        }
-
-        const secretBundle = await SecretService.deleteSecret({
-            apiRequest: instance.clientConfig.apiRequest,
-            workspaceKey: instance.clientConfig.workspaceConfig.workspaceKey,
-            workspaceId: instance.clientConfig.workspaceConfig?.workspaceId,
-            environment: options.environment,
-            type: options.type,
-            path: options.path,
-            secretName
-        });
-
-        const cacheKey = `${options.type}-${secretName}`;
-        delete instance.cache[cacheKey];
-
-        return secretBundle;
-
-    } catch (err) {
-        if (instance.debug) console.error(err);
-
-        return await SecretService.getFallbackSecret({
-            secretName
-        })
+    if (!instance.clientConfig.workspaceConfig) {
+      instance.clientConfig.workspaceConfig = await SecretService.populateClientWorkspaceConfig(instance.clientConfig);
     }
+
+    const secretBundle = await SecretService.deleteSecret({
+      apiRequest: instance.clientConfig.apiRequest,
+      workspaceKey: instance.clientConfig.workspaceConfig.workspaceKey,
+      workspaceId: instance.clientConfig.workspaceConfig.workspaceId,
+      environment: options.environment,
+      type: options.type,
+      path: options.path,
+      secretName,
+    });
+
+    const cacheKey = `${options.type}-${secretName}`;
+    delete instance.cache[cacheKey];
+
+    return secretBundle;
+  } catch (err) {
+    if (instance.debug) console.error(err);
+
+    return await SecretService.getFallbackSecret({
+      secretName,
+    });
+  }
+}
+
+export async function listFoldersHelper(instance: InfisicalClient, options: FolderOptions): Promise<IFolder[]> {
+  try {
+    if (!instance.clientConfig) throw Error("Failed to find client config");
+
+    if (!instance.clientConfig.workspaceConfig) {
+      instance.clientConfig.workspaceConfig = await SecretService.populateClientWorkspaceConfig(instance.clientConfig);
+    }
+
+    const folders = await listFolders(instance.clientConfig.apiRequest, {
+      workspaceId: instance.clientConfig.workspaceConfig.workspaceId,
+      environment: options.environment,
+      directory: options.directory,
+    });
+
+    return folders;
+  } catch (err) {
+    if (instance.debug) console.error(err);
+
+    return [];
+  }
+}
+
+export async function createFolderHelper(
+  instance: InfisicalClient,
+  name: string,
+  options: FolderOptions
+): Promise<IFolder | null> {
+  try {
+    if (!instance.clientConfig) throw Error("Failed to find client config");
+
+    if (!instance.clientConfig.workspaceConfig) {
+      instance.clientConfig.workspaceConfig = await SecretService.populateClientWorkspaceConfig(instance.clientConfig);
+    }
+
+    const folder = await createFolder(instance.clientConfig.apiRequest, {
+      workspaceId: instance.clientConfig.workspaceConfig.workspaceId,
+      environment: options.environment,
+      folderName: name,
+      directory: options.directory,
+    });
+
+    return folder;
+  } catch (err) {
+    if (instance.debug) console.error(err);
+
+    return null;
+  }
+}
+
+export async function updateFolderHelper(
+  instance: InfisicalClient,
+  name: string,
+  newName: string,
+  options: FolderOptions
+): Promise<IFolder | null> {
+  try {
+    if (!instance.clientConfig) throw Error("Failed to find client config");
+
+    if (!instance.clientConfig.workspaceConfig) {
+      instance.clientConfig.workspaceConfig = await SecretService.populateClientWorkspaceConfig(instance.clientConfig);
+    }
+
+    const updateFolderResponse = await updateFolder(instance.clientConfig.apiRequest, {
+      workspaceId: instance.clientConfig.workspaceConfig.workspaceId,
+      environment: options.environment,
+      folderName: name,
+      name: newName,
+      directory: options.directory,
+    });
+
+    return updateFolderResponse.folder;
+  } catch (err) {
+    if (instance.debug) console.error(err);
+
+    return null;
+  }
+}
+
+export async function deleteFolderHelper(
+  instance: InfisicalClient,
+  name: string,
+  options: FolderOptions
+): Promise<IFolder[] | null> {
+  try {
+    if (!instance.clientConfig) throw Error("Failed to find client config");
+
+    if (!instance.clientConfig.workspaceConfig) {
+      instance.clientConfig.workspaceConfig = await SecretService.populateClientWorkspaceConfig(instance.clientConfig);
+    }
+
+    const deleteFolderResponse = await deleteFolder(instance.clientConfig.apiRequest, {
+      workspaceId: instance.clientConfig.workspaceConfig.workspaceId,
+      environment: options.environment,
+      folderName: name,
+      directory: options.directory,
+    });
+
+    return deleteFolderResponse.folders;
+  } catch (err) {
+    if (instance.debug) console.error(err);
+
+    return null;
+  }
 }

--- a/src/types/InfisicalClient.d.ts
+++ b/src/types/InfisicalClient.d.ts
@@ -1,64 +1,67 @@
-import { AxiosInstance } from 'axios';
+import { AxiosInstance } from "axios";
 
 export interface InfisicalClientOptions {
-    token?: string;
-    tokenJson?: string;
-    siteURL?: string;
-    debug?: boolean;
-    cacheTTL?: number;
+  token?: string;
+  tokenJson?: string;
+  siteURL?: string;
+  debug?: boolean;
+  cacheTTL?: number;
 }
 
 export interface WorkspaceConfig {
-    workspaceId: string;
-    workspaceKey: string;
+  workspaceId: string;
+  workspaceKey: string;
 }
 
 interface ServiceTokenCredentials {
-    serviceTokenKey: string;
+  serviceTokenKey: string;
 }
 
 interface BaseConfig {
-    apiRequest: AxiosInstance;
-    cacheTTL: number;
+  apiRequest: AxiosInstance;
+  cacheTTL: number;
 }
 
 export interface ServiceTokenClientConfig extends BaseConfig {
-    authMode: "serviceToken"; // TODO: convert to enum
-    credentials: ServiceTokenCredentials;
-    workspaceConfig?: WorkspaceConfig;
+  authMode: "serviceToken"; // TODO: convert to enum
+  credentials: ServiceTokenCredentials;
+  workspaceConfig?: WorkspaceConfig;
 }
 
 interface ServiceTokenV3Credentials {
-    publicKey: string;
-    privateKey: string;
+  publicKey: string;
+  privateKey: string;
 }
 
 export interface ServiceTokenV3ClientConfig extends BaseConfig {
-    authMode: "serviceTokenV3"; // TODO: convert to enum
-    credentials: ServiceTokenV3Credentials;
-    workspaceConfig?: WorkspaceConfig;
+  authMode: "serviceTokenV3"; // TODO: convert to enum
+  credentials: ServiceTokenV3Credentials;
+  workspaceConfig?: WorkspaceConfig;
 }
 
-export type ClientConfig =
-    | ServiceTokenClientConfig
-    | ServiceTokenV3ClientConfig;
+export type ClientConfig = ServiceTokenClientConfig | ServiceTokenV3ClientConfig;
 
-type SecretType = 'shared' | 'personal'
+type SecretType = "shared" | "personal";
 
 interface Options {
-    type: SecretType;
-    environment: string;
-    path: string;
+  type: SecretType;
+  environment: string;
+  path: string;
 }
 
 export interface GetAllOptions {
-    environment: string;
-    path: string;
-    attachToProcessEnv: boolean;
-    includeImports: boolean
+  environment: string;
+  path: string;
+  attachToProcessEnv: boolean;
+  includeImports: boolean;
 }
 
-export interface GetOptions extends Options { }
-export interface CreateOptions extends Options { }
-export interface UpdateOptions extends Options { }
-export interface DeleteOptions extends Options { }
+export interface GetOptions extends Options {}
+export interface CreateOptions extends Options {}
+export interface UpdateOptions extends Options {}
+export interface DeleteOptions extends Options {}
+
+export interface FolderOptions {
+  environment: string;
+  directory: string;
+}

--- a/src/types/api.d.ts
+++ b/src/types/api.d.ts
@@ -2,71 +2,101 @@ import { AxiosInstance } from "axios";
 import { ISecret } from "./models";
 
 export interface ApiRequestInterceptorProps {
-    baseURL: string;
-    serviceToken: string;
+  baseURL: string;
+  serviceToken: string;
 }
 
 export interface GetSecretsDTO {
-    workspaceId: string;
-    environment: string;
-    path: string;
-    includeImports: boolean
+  workspaceId: string;
+  environment: string;
+  path: string;
+  includeImports: boolean;
 }
 
 export interface GetSecretDTO {
-    secretName: string;
-    workspaceId: string;
-    environment: string;
-    path: string;
-    type: 'shared' | 'personal';
+  secretName: string;
+  workspaceId: string;
+  environment: string;
+  path: string;
+  type: "shared" | "personal";
 }
 
 export interface CreateSecretDTO {
-    secretName: string;
-    workspaceId: string;
-    environment: string;
-    path: string;
-    type: 'shared' | 'personal';
-    secretKeyCiphertext: string;
-    secretKeyIV: string;
-    secretKeyTag: string;
-    secretValueCiphertext: string;
-    secretValueIV: string;
-    secretValueTag: string;
-    secretCommentCiphertext?: string;
-    secretCommentIV?: string;
-    secretCommentTag?: string;
+  secretName: string;
+  workspaceId: string;
+  environment: string;
+  path: string;
+  type: "shared" | "personal";
+  secretKeyCiphertext: string;
+  secretKeyIV: string;
+  secretKeyTag: string;
+  secretValueCiphertext: string;
+  secretValueIV: string;
+  secretValueTag: string;
+  secretCommentCiphertext?: string;
+  secretCommentIV?: string;
+  secretCommentTag?: string;
 }
 
 export interface UpdateSecretDTO {
-    secretName: string;
-    workspaceId: string;
-    environment: string;
-    type: 'shared' | 'personal'
-    path: string;
-    secretValueCiphertext: string;
-    secretValueIV: string;
-    secretValueTag: string;
+  secretName: string;
+  workspaceId: string;
+  environment: string;
+  type: "shared" | "personal";
+  path: string;
+  secretValueCiphertext: string;
+  secretValueIV: string;
+  secretValueTag: string;
 }
 
 export interface DeleteSecretDTO {
-    secretName: string;
-    workspaceId: string;
-    environment: string;
-    path: string;
-    type: 'shared' | 'personal';
+  secretName: string;
+  workspaceId: string;
+  environment: string;
+  path: string;
+  type: "shared" | "personal";
 }
 
 export interface ImportedSecrets {
-    environment: string;
-    folderId: string;
-    secretPath: string;
-    secrets: ISecret[];
+  environment: string;
+  folderId: string;
+  secretPath: string;
+  secrets: ISecret[];
 }
 
 export type AllSecretsResponse = {
-    secrets: ISecret[],
-    imports: ImportedSecrets[]
+  secrets: ISecret[];
+  imports: ImportedSecrets[];
+};
+
+export interface ListFoldersDTO {
+  workspaceId: string;
+  environment: string;
+  directory?: string;
+}
+
+export interface CreateFolderDTO {
+  directory?: string;
+  environment: string;
+  folderName: string;
+  workspaceId: string;
+}
+
+export interface UpdateFolderDTO {
+  /** Name of the folder to update */
+  folderName: string;
+  /** New name for the folder */
+  name: string;
+  directory?: string;
+  environment: string;
+  workspaceId: string;
+}
+
+export interface DeleteFolderDTO {
+  folderName: string;
+  directory?: string;
+  environment: string;
+  workspaceId: string;
 }
 
 export { AxiosInstance };

--- a/src/types/models.d.ts
+++ b/src/types/models.d.ts
@@ -1,63 +1,72 @@
 export interface ISecret {
-    _id: string;
-    version: number;
-    workspace: string;
-    user?: string;
-    type: 'shared' | 'personal';
-    environment: string;
-    secretKeyCiphertext: string;
-    secretKeyIV: string;
-    secretKeyTag: string;
-    secretValueCiphertext: string;
-    secretValueIV: string;
-    secretValueTag: string;
-    secretCommentCiphertext?: string;
-    secretCommentIV?: string;
-    secretCommentTag?: string;
-    createdAt: string;
-    updatedAt: string;
+  _id: string;
+  version: number;
+  workspace: string;
+  user?: string;
+  type: "shared" | "personal";
+  environment: string;
+  secretKeyCiphertext: string;
+  secretKeyIV: string;
+  secretKeyTag: string;
+  secretValueCiphertext: string;
+  secretValueIV: string;
+  secretValueTag: string;
+  secretCommentCiphertext?: string;
+  secretCommentIV?: string;
+  secretCommentTag?: string;
+  createdAt: string;
+  updatedAt: string;
 }
 
 export interface ISecretBundle {
-    secretName: string;
-    secretValue: string | undefined;
-    version?: number;
-    workspace?: string;
-    environment?: string;
-    type?: 'shared' | 'personal'
-    createdAt?: string;
-    updatedAt?: string;
-    isFallback: boolean;
-    lastFetchedAt: Date;
+  secretName: string;
+  secretValue: string | undefined;
+  version?: number;
+  workspace?: string;
+  environment?: string;
+  type?: "shared" | "personal";
+  createdAt?: string;
+  updatedAt?: string;
+  isFallback: boolean;
+  lastFetchedAt: Date;
 }
 
 export interface IServiceTokenData {
-    _id: string;
-    name: string;
-    workspace: string;
-    environment: string;
-    user: string;
-    serviceAccount: string;
-    lastUsed: Date;
-    expiresAt: Date;
-    encryptedKey: string;
-    iv: string;
-    tag: string;
-    createdAt: string;
-    updatedAt: string;
+  _id: string;
+  name: string;
+  workspace: string;
+  environment: string;
+  user: string;
+  serviceAccount: string;
+  lastUsed: Date;
+  expiresAt: Date;
+  encryptedKey: string;
+  iv: string;
+  tag: string;
+  createdAt: string;
+  updatedAt: string;
 }
 
 export interface Scope {
-    envSlug: string;
-    path: string
+  envSlug: string;
+  path: string;
 }
 
 export interface ServiceTokenDataKeyRes {
-    key: {
-        _id: string;    
-        workspace: string;
-        encryptedKey: string;
-        publicKey: string;
-        nonce: string;
-    }
+  key: {
+    _id: string;
+    workspace: string;
+    encryptedKey: string;
+    publicKey: string;
+    nonce: string;
+  };
+}
+
+export interface IFolder {
+  id: string;
+  name: string;
+}
+
+export interface IFolderWithVersion extends IFolder {
+  version: number;
 }

--- a/tests/client/InfisicalClient.test.ts
+++ b/tests/client/InfisicalClient.test.ts
@@ -1,158 +1,177 @@
-require('dotenv').config();
-import { describe, expect } from '@jest/globals';
-import InfisicalClient from '../../src';
+require("dotenv").config();
+import { describe, expect } from "@jest/globals";
+import InfisicalClient from "../../src";
 
-describe('InfisicalClient', () => {
-    let client: InfisicalClient;
-    beforeAll(async () => {
-        client = new InfisicalClient({
-            token: process.env.INFISICAL_TOKEN!,
-            tokenJson: process.env.INFISICAL_TOKEN_JSON!,
-            siteURL: process.env.SITE_URL!,
-            debug: true
-        });
-        await client.createSecret('KEY_ONE', 'KEY_ONE_VAL');
-        await client.createSecret('KEY_ONE', 'KEY_ONE_VAL_PERSONAL', {
-            type: "personal",
-            environment: "dev",
-            path: "/"
-        });
-        await client.createSecret('KEY_TWO', 'KEY_TWO_VAL');
-    }, 10000);
+describe("InfisicalClient", () => {
+  let client: InfisicalClient;
+  beforeAll(async () => {
+    client = new InfisicalClient({
+      token: process.env.INFISICAL_TOKEN!,
+      tokenJson: process.env.INFISICAL_TOKEN_JSON!,
+      siteURL: process.env.SITE_URL!,
+      debug: true,
+    });
+    await client.createSecret("KEY_ONE", "KEY_ONE_VAL");
+    await client.createSecret("KEY_ONE", "KEY_ONE_VAL_PERSONAL", {
+      type: "personal",
+      environment: "dev",
+      path: "/",
+    });
+    await client.createSecret("KEY_TWO", "KEY_TWO_VAL");
+    await client.createFolder("FOLDER_ONE");
+  }, 10000);
 
-    afterAll(async () => {
-        await client.deleteSecret('KEY_ONE');
-        await client.deleteSecret('KEY_TWO');
-        await client.deleteSecret('KEY_THREE');
-    }, 10000);
+  afterAll(async () => {
+    await client.deleteSecret("KEY_ONE");
+    await client.deleteSecret("KEY_TWO");
+    await client.deleteSecret("KEY_THREE");
+    await client.deleteFolder("FOLDER_ONE");
+  }, 10000);
 
-    it('get overriden personal secret', async () => {
-        const secret = await client.getSecret('KEY_ONE', {
-            type: "personal",
-            environment: "dev",
-            path: "/"
-        });
-
-        expect(secret.secretName).toBe('KEY_ONE');
-        expect(secret.secretValue).toBe('KEY_ONE_VAL_PERSONAL');
-        expect(secret.type).toBe('personal');
+  it("get overriden personal secret", async () => {
+    const secret = await client.getSecret("KEY_ONE", {
+      type: "personal",
+      environment: "dev",
+      path: "/",
     });
 
-    it('get shared secret specified', async () => {
-        const secret = await client.getSecret('KEY_ONE', {
-            type: 'shared',
-            environment: "dev",
-            path: "/"
-        });
+    expect(secret.secretName).toBe("KEY_ONE");
+    expect(secret.secretValue).toBe("KEY_ONE_VAL_PERSONAL");
+    expect(secret.type).toBe("personal");
+  });
 
-        expect(secret.secretName).toBe('KEY_ONE');
-        expect(secret.secretValue).toBe('KEY_ONE_VAL');
-        expect(secret.type).toBe('shared');
+  it("get shared secret specified", async () => {
+    const secret = await client.getSecret("KEY_ONE", {
+      type: "shared",
+      environment: "dev",
+      path: "/",
     });
 
-    it('get shared secret', async () => {
-        const secret = await client.getSecret('KEY_TWO');
+    expect(secret.secretName).toBe("KEY_ONE");
+    expect(secret.secretValue).toBe("KEY_ONE_VAL");
+    expect(secret.type).toBe("shared");
+  });
 
-        expect(secret.secretName).toBe('KEY_TWO');
-        expect(secret.secretValue).toBe('KEY_TWO_VAL');
-        expect(secret.type).toBe('shared');
+  it("get shared secret", async () => {
+    const secret = await client.getSecret("KEY_TWO");
+
+    expect(secret.secretName).toBe("KEY_TWO");
+    expect(secret.secretValue).toBe("KEY_TWO_VAL");
+    expect(secret.type).toBe("shared");
+  });
+
+  it("create shared secret", async () => {
+    const secret = await client.createSecret("KEY_THREE", "KEY_THREE_VAL");
+
+    expect(secret.secretName).toBe("KEY_THREE");
+    expect(secret.secretValue).toBe("KEY_THREE_VAL");
+    expect(secret.type).toBe("shared");
+  });
+
+  it("create personal secret", async () => {
+    await client.createSecret("KEY_FOUR", "KEY_FOUR_VAL");
+    const secretPersonal = await client.createSecret("KEY_FOUR", "KEY_FOUR_VAL_PERSONAL", {
+      type: "personal",
+      environment: "dev",
+      path: "/",
     });
 
-    it('create shared secret', async () => {
-        const secret = await client.createSecret('KEY_THREE', 'KEY_THREE_VAL');
+    expect(secretPersonal.secretName).toBe("KEY_FOUR");
+    expect(secretPersonal.secretValue).toBe("KEY_FOUR_VAL_PERSONAL");
+    expect(secretPersonal.type).toBe("personal");
+  });
 
-        expect(secret.secretName).toBe('KEY_THREE');
-        expect(secret.secretValue).toBe('KEY_THREE_VAL');
-        expect(secret.type).toBe('shared');
+  it("update shared secret", async () => {
+    const secret = await client.updateSecret("KEY_THREE", "FOO");
+
+    expect(secret.secretName).toBe("KEY_THREE");
+    expect(secret.secretValue).toBe("FOO");
+    expect(secret.type).toBe("shared");
+  });
+
+  it("update personal secret", async () => {
+    const secret = await client.updateSecret("KEY_FOUR", "BAR", {
+      type: "personal",
+      environment: "dev",
+      path: "/",
     });
 
-    it('create personal secret', async () => {
-        await client.createSecret('KEY_FOUR', 'KEY_FOUR_VAL');
-        const secretPersonal = await client.createSecret('KEY_FOUR', 'KEY_FOUR_VAL_PERSONAL', {
-            type: "personal",
-            environment: "dev",
-            path: "/"
-        });
+    expect(secret.secretName).toBe("KEY_FOUR");
+    expect(secret.secretValue).toBe("BAR");
+    expect(secret.type).toBe("personal");
+  });
 
-        expect(secretPersonal.secretName).toBe('KEY_FOUR');
-        expect(secretPersonal.secretValue).toBe('KEY_FOUR_VAL_PERSONAL');
-        expect(secretPersonal.type).toBe('personal');
+  it("delete personal secret", async () => {
+    const secret = await client.deleteSecret("KEY_FOUR", {
+      type: "personal",
+      environment: "dev",
+      path: "/",
     });
 
-    it('update shared secret', async () => {
-        const secret = await client.updateSecret('KEY_THREE', 'FOO');
+    expect(secret.secretName).toBe("KEY_FOUR");
+    expect(secret.secretValue).toBe("BAR");
+    expect(secret.type).toBe("personal");
+  });
 
-        expect(secret.secretName).toBe('KEY_THREE');
-        expect(secret.secretValue).toBe('FOO');
-        expect(secret.type).toBe('shared');
-    });
+  it("delete shared secret", async () => {
+    const secret = await client.deleteSecret("KEY_FOUR");
 
-    it('update personal secret', async () => {
-        const secret = await client.updateSecret('KEY_FOUR', 'BAR', {
-            type: "personal",
-            environment: "dev",
-            path: "/"
-        });
+    expect(secret.secretName).toBe("KEY_FOUR");
+    expect(secret.secretValue).toBe("KEY_FOUR_VAL");
+    expect(secret.type).toBe("shared");
+  });
 
-        expect(secret.secretName).toBe('KEY_FOUR');
-        expect(secret.secretValue).toBe('BAR');
-        expect(secret.type).toBe('personal');
-    });
+  it("attach all to process.env", async () => {
+    // note: getAllSecrets returns dupliate shared + personal ones at the moment,
+    // should it default to personal?
+    // const secretBundles = await client.getAllSecrets({
+    //     environment: "dev",
+    //     path: "/",
+    //     attachToProcessEnv: true,
+    //     includeImports: false
+    // });
+    // can't test this because both key are same, only type is diff
+    // secretBundles.forEach((secretBundle) => {
+    //     expect(process.env[secretBundle.secretName]).toBe(secretBundle.secretValue);
+    // });
+  });
 
-    it('delete personal secret', async () => {
-        const secret = await client.deleteSecret('KEY_FOUR', {
-            type: "personal",
-            environment: "dev",
-            path: "/"
-        });
+  it("get folder", async () => {
+    const folders = await client.listFolders();
 
-        expect(secret.secretName).toBe('KEY_FOUR');
-        expect(secret.secretValue).toBe('BAR');
-        expect(secret.type).toBe('personal');
-    });
+    expect(folders.length).toBeGreaterThan(0);
 
-    it('delete shared secret', async () => {
-        const secret = await client.deleteSecret('KEY_FOUR');
+    const folder = folders.find((f) => f.name === "FOLDER_ONE");
+    expect(folder?.name).toEqual("FOLDER_ONE");
+  });
 
-        expect(secret.secretName).toBe('KEY_FOUR');
-        expect(secret.secretValue).toBe('KEY_FOUR_VAL');
-        expect(secret.type).toBe('shared');
-    });
+  it("create folder", async () => {
+    const folder = await client.createFolder("FOLDER_TWO");
+    expect(folder?.name).toEqual("FOLDER_TWO");
+  });
 
-    it('attach all to process.env', async () => {
-        // note: getAllSecrets returns dupliate shared + personal ones at the moment,
-        // should it default to personal?
-        // const secretBundles = await client.getAllSecrets({
-        //     environment: "dev",
-        //     path: "/",
-        //     attachToProcessEnv: true,
-        //     includeImports: false
-        // });
+  it("update folder", async () => {
+    const folder = await client.updateFolder("FOLDER_TWO", "FOLDER_THREE");
+    expect(folder?.name).toEqual("FOLDER_THREE");
+  });
 
-        // can't test this because both key are same, only type is diff 
-        // secretBundles.forEach((secretBundle) => {
-        //     expect(process.env[secretBundle.secretName]).toBe(secretBundle.secretValue);
-        // });
-    });
+  it("delete folder", async () => {
+    const folders = await client.deleteFolder("FOLDER_THREE");
+    expect(folders?.length).toBeGreaterThan(0);
 
-    it('encrypt/decrypt symmetric', () => {
-        const plaintext = 'The quick brown fox jumps over the lazy dog';
+    const deleted = folders?.find((f) => f.name === "FOLDER_THREE");
+    expect(deleted?.name).toEqual("FOLDER_THREE");
+  });
 
-        const key = client.createSymmetricKey();
+  it("encrypt/decrypt symmetric", () => {
+    const plaintext = "The quick brown fox jumps over the lazy dog";
 
-        const {
-            ciphertext,
-            iv,
-            tag
-        } = client.encryptSymmetric(plaintext, key);
+    const key = client.createSymmetricKey();
 
-        const cleartext = client.decryptSymmetric(
-            ciphertext,
-            key,
-            iv,
-            tag
-        );
+    const { ciphertext, iv, tag } = client.encryptSymmetric(plaintext, key);
 
-        expect(plaintext).toBe(cleartext);
-    });
+    const cleartext = client.decryptSymmetric(ciphertext, key, iv, tag);
+
+    expect(plaintext).toBe(cleartext);
+  });
 });


### PR DESCRIPTION
# Folder API endpoints

Implements the basic [folder logic from the API](https://infisical.com/docs/api-reference/endpoints/folders/list). This will allow for the creation, listing, updating, and deletion of folders via the SDK.

Not for this PR but eventually this can be integrated more naturally into the SDK behaviour. For example, if a user creates a secret at a folder that does not yet exist then this folder may be created (possibly configurable).