### PR TITLE
Add built-in cli functionality to the node package

### DIFF
--- a/lib/cli/index.js
+++ b/lib/cli/index.js
@@ -1,0 +1,29 @@
+#!/usr/bin/env node
+const { program } = require('commander');
+const InfisicalClient = require('../index');
+
+// Document available cli args
+program
+  .name('npx infisical-node/cli')
+  .description('Load Infisical env variables into process.env')
+  .argument('<token>', 'Infisical API token')
+  .argument('<env>', 'Environment in Infisical')
+  .argument('<path>', 'Secrets path');
+
+// Load args from user
+program.parse();
+
+// Load secrets into process.env
+(async function () {
+  const client = new InfisicalClient({
+    token: program.args[0],
+  });
+
+  await client.getAllSecrets({
+    environment: program.args[1],
+    path: program.args[2],
+    attachToProcessEnv: true,
+    includeImports: false,
+  });
+})()
+

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,9 +10,13 @@
       "license": "ISC",
       "dependencies": {
         "axios": "^1.3.3",
+        "commander": "^12.0.0",
         "dotenv": "^16.0.3",
         "tweetnacl": "^1.0.3",
         "tweetnacl-util": "^0.15.1"
+      },
+      "bin": {
+        "infisical-node": "lib/cli/index.js"
       },
       "devDependencies": {
         "@babel/cli": "^7.21.0",
@@ -67,6 +71,15 @@
       },
       "peerDependencies": {
         "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/cli/node_modules/commander": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
+      "integrity": "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==",
+      "dev": true,
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/@babel/cli/node_modules/convert-source-map": {
@@ -2836,12 +2849,11 @@
       }
     },
     "node_modules/commander": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
-      "integrity": "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==",
-      "dev": true,
+      "version": "12.0.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-12.0.0.tgz",
+      "integrity": "sha512-MwVNWlYjDTtOjX5PiD7o5pK0UrFU/OYgcJfjjK4RaHZETNtjJqrZa9Y9ds88+A+f+d5lv+561eZ+yCKoS3gbAA==",
       "engines": {
-        "node": ">= 6"
+        "node": ">=18"
       }
     },
     "node_modules/concat-map": {
@@ -5292,6 +5304,12 @@
         "slash": "^2.0.0"
       },
       "dependencies": {
+        "commander": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
+          "integrity": "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==",
+          "dev": true
+        },
         "convert-source-map": {
           "version": "1.9.0",
           "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.9.0.tgz",
@@ -7321,10 +7339,9 @@
       }
     },
     "commander": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
-      "integrity": "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==",
-      "dev": true
+      "version": "12.0.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-12.0.0.tgz",
+      "integrity": "sha512-MwVNWlYjDTtOjX5PiD7o5pK0UrFU/OYgcJfjjK4RaHZETNtjJqrZa9Y9ds88+A+f+d5lv+561eZ+yCKoS3gbAA=="
     },
     "concat-map": {
       "version": "0.0.1",

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "build": "rm -rf lib && tsc && cp -R ./src/types ./lib",
     "test": "jest"
   },
+  "bin": "./lib/cli/index.js",
   "author": "",
   "license": "ISC",
   "devDependencies": {
@@ -23,6 +24,7 @@
   },
   "dependencies": {
     "axios": "^1.3.3",
+    "commander": "^12.0.0",
     "dotenv": "^16.0.3",
     "tweetnacl": "^1.0.3",
     "tweetnacl-util": "^0.15.1"


### PR DESCRIPTION
## What is this feature?
This allows the infisical-node SDK to be used as a cli to load env vars.
`npx infisical-node [token] [env] [path] && node index.js`

## Why would you want this?
Infisical currently maintains a cli that users can use to populate the environment with env variables (or native integrations). But the cli has its own installation steps and adds another layer of complexity to the Infisical ecosystem. Why do we even need a cli when we could just use the node package itself?

## How would end users use this feature
After installing `npm i infisical-node`, you can simply run the node package like an executable.

Instead of:
`infisical run --env=staging --path=/apps/spotify -- node index.js`

Users would:
`npx infisical-node [token] [env] [path] && node index.js`

## How the feature works
It uses the very popular `commander` package to load command line args. Then it initializes an `InfisicalClient` and fetches secrets.